### PR TITLE
Code cleaning

### DIFF
--- a/extensions/permessage-deflate/permessage-deflate.c
+++ b/extensions/permessage-deflate/permessage-deflate.c
@@ -286,13 +286,13 @@ void onInit(char *config) {
     regex_t re;
     size_t nmatch = 8;
     regmatch_t matches[nmatch];
-    size_t params_length = strlen(config);
-    char buffer[params_length+1];
     const char *reg_str = "^(\\s*((server_no_context_takeover)|(server_max_window_bits\\s*=\\s*[0-9]+)|(client_max_window_bits\\s*=\\s*[0-9]+)|(memory_level\\s*=\\s*[0-9]+)|(chunk_size\\s*=\\s*[0-9]+))\\s*;?\\s*)*$";
 
     if ( NULL == config ) {
         return;
     }
+    size_t params_length = strlen(config);
+    char buffer[params_length+1];
 
     if ( unlikely((err = regcomp(&re, reg_str, REG_EXTENDED)) != 0) ) {
         return;
@@ -410,9 +410,7 @@ void onOpen(int fd, char *param, char **accepted, bool *valid) {
     regex_t re;
     size_t nmatch = 7;
     regmatch_t matches[nmatch];
-    size_t params_length = strlen(param);
     wss_comp_t *comp;
-    char buffer[params_length+1];
     const char *reg_str = "^(\\s*((server_no_context_takeover)|(client_no_context_takeover)|(server_max_window_bits\\s*=\\s*[0-9]+)|(client_max_window_bits(\\s*=\\s*[0-9]+)?))*\\s*;?\\s*)*$";
 
     if ( NULL == param ) {
@@ -445,6 +443,8 @@ void onOpen(int fd, char *param, char **accepted, bool *valid) {
         *valid = true;
         return;
     }
+    size_t params_length = strlen(param);
+    char buffer[params_length+1];
 
     if ( unlikely((err = regcomp(&re, reg_str, REG_EXTENDED)) != 0) ) {
         *valid = false;

--- a/extensions/permessage-deflate/permessage-deflate.c
+++ b/extensions/permessage-deflate/permessage-deflate.c
@@ -595,8 +595,6 @@ void inFrames(int fd, wss_frame_t **frames, size_t len) {
     }
 
     // Decompress data
-    comp->compressor.avail_in = payload_length;
-    comp->compressor.next_in = (unsigned char *)payload;
     do {
         if ( unlikely(NULL == (message = allocs.realloc(message, (message_length+default_chunk_size+1)*sizeof(char)))) ) {
             allocs.free(message);

--- a/src/header.c
+++ b/src/header.c
@@ -218,9 +218,9 @@ enum HttpStatus_Code WSS_parse_header(int fd, wss_header_t *header, wss_config_t
         }
 
         line = strtok_r(token, ":", &lineptr);
-        line_length = strlen(line);
 
         if ( likely(line != NULL) ) {
+            line_length = strlen(line);
             if ( line_length == strlen(SEC_WEBSOCKET_VERSION) && 
                 strncasecmp(SEC_WEBSOCKET_VERSION, line, line_length) == 0 ) {
                 // The |Sec-WebSocket-Version| header field MUST NOT appear more than once in an HTTP request.

--- a/src/json.c
+++ b/src/json.c
@@ -278,7 +278,7 @@ json_value * json_parse_ex (json_settings * settings,
          if (flags & flag_string)
          {
             if (!b)
-            {  sprintf (error, "Unexpected EOF in string (at %d:%d)", line_and_col);
+            {  sprintf (error, "Unexpected EOF in string (at %u:%u)", line_and_col);
                goto e_failed;
             }
 
@@ -304,7 +304,7 @@ json_value * json_parse_ex (json_settings * settings,
                         (uc_b3 = hex_value (*++ state.ptr)) == 0xFF ||
                         (uc_b4 = hex_value (*++ state.ptr)) == 0xFF)
                     {
-                        sprintf (error, "Invalid character value `%c` (at %d:%d)", b, line_and_col);
+                        sprintf (error, "Invalid character value `%c` (at %u:%u)", b, line_and_col);
                         goto e_failed;
                     }
 
@@ -320,7 +320,7 @@ if ((uchar & 0xF800) == 0xD800) {
                             (uc_b3 = hex_value (*++ state.ptr)) == 0xFF ||
                             (uc_b4 = hex_value (*++ state.ptr)) == 0xFF)
                         {
-                            sprintf (error, "Invalid character value `%c` (at %d:%d)", b, line_and_col);
+                            sprintf (error, "Invalid character value `%c` (at %u:%u)", b, line_and_col);
                             goto e_failed;
                         }
 
@@ -449,7 +449,7 @@ if ((uchar & 0xF800) == 0xD800) {
                if (flags & flag_block_comment)
                {
                   if (!b)
-                  {  sprintf (error, "%d:%d: Unexpected EOF in block comment", line_and_col);
+                  {  sprintf (error, "%u:%u: Unexpected EOF in block comment", line_and_col);
                      goto e_failed;
                   }
 
@@ -465,12 +465,12 @@ if ((uchar & 0xF800) == 0xD800) {
             else if (b == '/')
             {
                if (! (flags & (flag_seek_value | flag_done)) && top->type != json_object)
-               {  sprintf (error, "%d:%d: Comment not allowed here", line_and_col);
+               {  sprintf (error, "%u:%u: Comment not allowed here", line_and_col);
                   goto e_failed;
                }
 
                if (++ state.ptr == end)
-               {  sprintf (error, "%d:%d: EOF unexpected", line_and_col);
+               {  sprintf (error, "%u:%u: EOF unexpected", line_and_col);
                   goto e_failed;
                }
 
@@ -485,7 +485,7 @@ if ((uchar & 0xF800) == 0xD800) {
                      continue;
 
                   default:
-                     sprintf (error, "%d:%d: Unexpected `%c` in comment opening sequence", line_and_col, b);
+                     sprintf (error, "%u:%u: Unexpected `%c` in comment opening sequence", line_and_col, b);
                      goto e_failed;
                };
             }
@@ -506,7 +506,7 @@ if ((uchar & 0xF800) == 0xD800) {
 
                default:
 
-                  sprintf (error, "%d:%d: Trailing garbage: `%c`",
+                  sprintf (error, "%u:%u: Trailing garbage: `%c`",
                            state.cur_line, state.cur_col, b);
 
                   goto e_failed;
@@ -528,7 +528,7 @@ if ((uchar & 0xF800) == 0xD800) {
                   if (top && top->type == json_array)
                      flags = (flags & ~ (flag_need_comma | flag_seek_value)) | flag_next;
                   else
-                  {  sprintf (error, "%d:%d: Unexpected ]", line_and_col);
+                  {  sprintf (error, "%u:%u: Unexpected ]", line_and_col);
                      goto e_failed;
                   }
 
@@ -544,7 +544,7 @@ if ((uchar & 0xF800) == 0xD800) {
                      }
                      else
                      {
-                        sprintf (error, "%d:%d: Expected , before %c",
+                        sprintf (error, "%u:%u: Expected , before %c",
                                  state.cur_line, state.cur_col, b);
 
                         goto e_failed;
@@ -559,7 +559,7 @@ if ((uchar & 0xF800) == 0xD800) {
                      }
                      else
                      {
-                        sprintf (error, "%d:%d: Expected : before %c",
+                        sprintf (error, "%u:%u: Expected : before %c",
                                  state.cur_line, state.cur_col, b);
 
                         goto e_failed;
@@ -685,7 +685,7 @@ if ((uchar & 0xF800) == 0xD800) {
                            continue;
                         }
                         else
-                        {  sprintf (error, "%d:%d: Unexpected %c when seeking value", line_and_col, b);
+                        {  sprintf (error, "%u:%u: Unexpected %c when seeking value", line_and_col, b);
                            goto e_failed;
                         }
                   };
@@ -708,7 +708,7 @@ if ((uchar & 0xF800) == 0xD800) {
                   case '"':
 
                      if (flags & flag_need_comma)
-                     {  sprintf (error, "%d:%d: Expected , before \"", line_and_col);
+                     {  sprintf (error, "%u:%u: Expected , before \"", line_and_col);
                         goto e_failed;
                      }
 
@@ -732,10 +732,10 @@ if ((uchar & 0xF800) == 0xD800) {
                         break;
                      }
 
-                     sprintf (error, "%d:%d: Unexpected `%c` in object", line_and_col, b);
+                     sprintf (error, "%u:%u: Unexpected `%c` in object", line_and_col, b);
                      goto e_failed;
                   default:
-                     sprintf (error, "%d:%d: Unexpected `%c` in object", line_and_col, b);
+                     sprintf (error, "%u:%u: Unexpected `%c` in object", line_and_col, b);
                      goto e_failed;
                };
 
@@ -753,7 +753,7 @@ if ((uchar & 0xF800) == 0xD800) {
                      if (! (flags & flag_num_e))
                      {
                         if (flags & flag_num_zero)
-                        {  sprintf (error, "%d:%d: Unexpected `0` before `%c`", line_and_col, b);
+                        {  sprintf (error, "%u:%u: Unexpected `0` before `%c`", line_and_col, b);
                            goto e_failed;
                         }
 
@@ -790,7 +790,7 @@ if ((uchar & 0xF800) == 0xD800) {
                else if (b == '.' && top->type == json_integer)
                {
                   if (!num_digits)
-                  {  sprintf (error, "%d:%d: Expected digit before `.`", line_and_col);
+                  {  sprintf (error, "%u:%u: Expected digit before `.`", line_and_col);
                      goto e_failed;
                   }
 
@@ -806,7 +806,7 @@ if ((uchar & 0xF800) == 0xD800) {
                   if (top->type == json_double)
                   {
                      if (!num_digits)
-                     {  sprintf (error, "%d:%d: Expected digit after `.`", line_and_col);
+                     {  sprintf (error, "%u:%u: Expected digit after `.`", line_and_col);
                         goto e_failed;
                      }
 
@@ -832,7 +832,7 @@ if ((uchar & 0xF800) == 0xD800) {
                else
                {
                   if (!num_digits)
-                  {  sprintf (error, "%d:%d: Expected digit after `e`", line_and_col);
+                  {  sprintf (error, "%u:%u: Expected digit after `e`", line_and_col);
                      goto e_failed;
                   }
 
@@ -918,7 +918,7 @@ if ((uchar & 0xF800) == 0xD800) {
 
 e_unknown_value:
 
-   sprintf (error, "%d:%d: Unknown value", line_and_col);
+   sprintf (error, "%u:%u: Unknown value", line_and_col);
    goto e_failed;
 
 e_alloc_failure:
@@ -928,7 +928,7 @@ e_alloc_failure:
 
 e_overflow:
 
-   sprintf (error, "%d:%d: Too long (caught overflow)", line_and_col);
+   sprintf (error, "%u:%u: Too long (caught overflow)", line_and_col);
    goto e_failed;
 
 e_failed:


### PR DESCRIPTION
Here is some small cleaning to avoid cppcheck warnings, and 2 lines removed from [permessage-deflate.c/inFrames](https://github.com/mortzdk/Websocket/blob/c5aecf9b7b82d1567182c5f07384354886f3282a/extensions/permessage-deflate/permessage-deflate.c#L598) that were useless there.

The cppcheck command used is: `cppcheck --force --enable=warning,missingInclude --error-exitcode=1 .`

cppcheck still complains about all the `unlikely` and `likely` macros but they seem to be false positive.